### PR TITLE
action: add flexibility around linting, testing, and building phases

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,21 @@
 
 ## Description
 
-A GitHub Action that builds JavaScript/TypeScript projects using PNPM and NX. This action is designed to work in conjunction with the [JavaScript PNPM Setup](https://github.com/p6m-actions/js-pnpm-setup) action, which handles Node.js installation, PNPM setup, and dependency caching.
+A GitHub Action that builds JavaScript/TypeScript projects using pnpm. This action provides flexible configuration for linting, testing, and building with sensible defaults and clear error reporting. It's designed to work with any pnpm-based project including Vue.js, Svelte/SvelteKit, Next.js, and other JavaScript/TypeScript frameworks.
+
+This action is designed to work in conjunction with the [JavaScript PNPM Setup](https://github.com/p6m-actions/js-pnpm-setup) action, which handles Node.js installation, PNPM setup, and dependency caching.
+
+## Features
+
+- **Flexible Configuration**: Customize lint, test, and build commands with your own scripts
+- **Sensible Defaults**: Works out-of-the-box with standard pnpm projects
+- **Toggleable Steps**: Enable or disable linting, testing, and building steps as needed
+- **Clear Error Reporting**: Each step provides clear feedback about failures
+- **Coverage Reports**: Option to archive test coverage reports
 
 ## Usage
+
+Basic usage with default settings:
 
 ```yaml
 - name: Setup PNPM
@@ -17,27 +29,64 @@ A GitHub Action that builds JavaScript/TypeScript projects using PNPM and NX. Th
 
 - name: Build
   uses: p6m-actions/js-pnpm-build@v1
+```
+
+Customized usage with specific commands:
+
+```yaml
+- name: Build
+  uses: p6m-actions/js-pnpm-build@v1
   with:
+    # Linting configuration
     run-lint: 'true'
+    lint-command: 'pnpm lint:strict'
+    lint-args: '--fix'
+    
+    # Testing configuration
+    run-test: 'true'
+    test-command: 'pnpm test:coverage'
+    
+    # Build configuration
+    run-build: 'true'
+    build-command: 'pnpm build:prod'
+    
+    # Archive coverage reports
     archive-coverage: 'true'
 ```
 
 ## Inputs
 
+### Lint Configuration
+
 | Name | Description | Default | Required |
 |------|-------------|---------|----------|
 | `run-lint` | Whether to run linting | `true` | No |
-| `lint-args` | Arguments for the lint command | `--all --parallel=5` | No |
-| `build-args` | Arguments for the build command | `--all --parallel=5 --prod --exclude docs` | No |
-| `node-options` | Node options for build process | `--max_old_space_size=4096` | No |
+| `lint-command` | Command to run for linting | `pnpm lint` | No |
+| `lint-args` | Additional arguments for the lint command | ` ` | No |
+
+### Test Configuration
+
+| Name | Description | Default | Required |
+|------|-------------|---------|----------|
+| `run-test` | Whether to run tests | `true` | No |
+| `test-command` | Command to run for testing | `pnpm test` | No |
+| `test-args` | Additional arguments for the test command | ` ` | No |
+
+### Build Configuration
+
+| Name | Description | Default | Required |
+|------|-------------|---------|----------|
+| `run-build` | Whether to run build | `true` | No |
+| `build-command` | Command to run for building | `pnpm build` | No |
+| `build-args` | Additional arguments for the build command | ` ` | No |
+
+### General Configuration
+
+| Name | Description | Default | Required |
+|------|-------------|---------|----------|
+| `node-options` | Node options for all processes | `--max_old_space_size=4096` | No |
 | `archive-coverage` | Whether to archive code coverage results | `false` | No |
 | `coverage-path` | Path to the coverage reports | `coverage` | No |
-
-## Outputs
-
-| Name | Description |
-|------|-------------|
-| `affected-apps` | List of affected applications |
 
 ## Examples
 
@@ -62,43 +111,61 @@ jobs:
       - name: Setup PNPM
         uses: p6m-actions/js-pnpm-setup@v1
         
-      - name: Build and Lint
+      - name: Build and Test
         uses: p6m-actions/js-pnpm-build@v1
 ```
 
-### Full Example with Custom Options
+### Only Run Linting
 
 ```yaml
-name: Build and Deploy
-
-on:
-  push:
-    branches: [ main ]
-
-jobs:
-  build:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Code
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-          
-      - name: Setup PNPM
-        uses: p6m-actions/js-pnpm-setup@v1
-        with:
-          node-version: '20'
-        
-      - name: Build and Lint
-        uses: p6m-actions/js-pnpm-build@v1
-        with:
-          run-lint: 'true'
-          lint-args: '--all --parallel=3'
-          build-args: '--all --parallel=3 --prod'
-          node-options: '--max_old_space_size=8192'
-          archive-coverage: 'true'
-          coverage-path: 'reports/coverage'
-          
-      - name: Get Apps
-        run: echo "Affected apps: ${{ steps.build.outputs.affected-apps }}"
+- name: Lint Only
+  uses: p6m-actions/js-pnpm-build@v1
+  with:
+    run-lint: 'true'
+    run-test: 'false' 
+    run-build: 'false'
 ```
+
+### Vue.js Project Example
+
+```yaml
+- name: Build Vue.js Project
+  uses: p6m-actions/js-pnpm-build@v1
+  with:
+    lint-command: 'pnpm lint:vue'
+    test-command: 'pnpm test:unit'
+    build-command: 'pnpm build:prod'
+```
+
+### Next.js Project Example
+
+```yaml
+- name: Build Next.js Project
+  uses: p6m-actions/js-pnpm-build@v1
+  with:
+    lint-command: 'pnpm lint'
+    test-command: 'pnpm test:ci'
+    build-command: 'pnpm build'
+    node-options: '--max_old_space_size=8192' # Next.js may need more memory
+```
+
+### Workspace Project Example
+
+```yaml
+- name: Build Workspace Project
+  uses: p6m-actions/js-pnpm-build@v1
+  with:
+    lint-command: 'pnpm -r lint'
+    test-command: 'pnpm -r test'
+    build-command: 'pnpm -r build'
+```
+
+## Troubleshooting
+
+### Common Issues
+
+1. **Command not found errors**: Make sure your package.json includes the scripts defined in your lint-command, test-command, and build-command inputs.
+
+2. **Out of memory errors**: If you encounter memory issues during build, increase the memory allocation with the node-options input.
+
+3. **pnpm workspace issues**: For monorepo projects using pnpm workspaces, you may need to use commands like `pnpm -r` to run commands recursively in all packages.

--- a/action.yml
+++ b/action.yml
@@ -1,25 +1,58 @@
 name: "JavaScript PNPM Build"
-description: "Builds a JavaScript project using PNPM and NX"
+description: "Builds a JavaScript/TypeScript project using pnpm with flexible lint, test, and build commands"
 author: "Jimmie Fulton <jimmie@ybor.ai>"
 
 # Define the inputs for this action
 inputs:
+  # Lint configuration
   run-lint:
     description: "Whether to run linting"
     required: false
     default: "true"
+  lint-command:
+    description: "Command to run for linting"
+    required: false
+    default: "pnpm lint"
   lint-args:
-    description: "Arguments for the lint command"
+    description: "Additional arguments for the lint command"
     required: false
-    default: "--all --parallel=5"
+    default: ""
+
+  # Test configuration
+  run-test:
+    description: "Whether to run tests"
+    required: false
+    default: "true"
+  test-command:
+    description: "Command to run for testing"
+    required: false
+    default: "pnpm test"
+  test-args:
+    description: "Additional arguments for the test command"
+    required: false
+    default: ""
+  
+  # Build configuration
+  run-build:
+    description: "Whether to run build"
+    required: false
+    default: "true"
+  build-command:
+    description: "Command to run for building"
+    required: false
+    default: "pnpm build"
   build-args:
-    description: "Arguments for the build command"
+    description: "Additional arguments for the build command"
     required: false
-    default: "--all --parallel=5 --prod --exclude docs"
+    default: ""
+  
+  # General configuration
   node-options:
-    description: "Node options for build process"
+    description: "Node options for all processes"
     required: false
     default: "--max_old_space_size=4096"
+  
+  # Coverage configuration
   archive-coverage:
     description: "Whether to archive code coverage results"
     required: false
@@ -29,12 +62,6 @@ inputs:
     required: false
     default: "coverage"
 
-# Define the outputs for this action
-outputs:
-  affected-apps:
-    description: "List of affected applications"
-    value: ${{ steps.affected-apps.outputs.apps }}
-
 # Define the runs configuration
 runs:
   using: "composite"
@@ -43,31 +70,68 @@ runs:
       shell: bash
       run: export NODE_OPTIONS="${{ inputs.node-options }}"
 
-    - name: Test / Lint
+    - name: Lint
       if: inputs.run-lint == 'true'
       shell: bash
-      run: pnpm nx run-many --target=lint ${{ inputs.lint-args }}
+      run: |
+        echo "::group::Running Lint"
+        echo "Running command: ${{ inputs.lint-command }} ${{ inputs.lint-args }}"
+        ${{ inputs.lint-command }} ${{ inputs.lint-args }} || {
+          echo "::error::Linting failed. Please check the logs above for errors."
+          exit 1
+        }
+        echo "::endgroup::"
+
+    - name: Test
+      if: inputs.run-test == 'true'
+      shell: bash
+      run: |
+        echo "::group::Running Tests"
+        echo "Running command: ${{ inputs.test-command }} ${{ inputs.test-args }}"
+        ${{ inputs.test-command }} ${{ inputs.test-args }} || {
+          echo "::error::Tests failed. Please check the logs above for errors."
+          exit 1
+        }
+        echo "::endgroup::"
 
     - name: Archive code coverage results
-      if: inputs.archive-coverage == 'true'
+      if: inputs.archive-coverage == 'true' && inputs.run-test == 'true'
       uses: actions/upload-artifact@v4
       with:
-        name: unit-tests-report
+        name: test-coverage-report
         path: ${{ inputs.coverage-path }}
 
     - name: Build
-      shell: bash
-      run: pnpm nx run-many --target=build ${{ inputs.build-args }}
-
-    - name: Get affected apps
-      id: affected-apps
+      if: inputs.run-build == 'true'
       shell: bash
       run: |
-        APPS=$(pnpm nx show projects --type app --exclude docs | cut -d, -f1)
-        echo "apps=$APPS" >> $GITHUB_OUTPUT
-        echo "Affected applications: $APPS"
+        echo "::group::Running Build"
+        echo "Running command: ${{ inputs.build-command }} ${{ inputs.build-args }}"
+        ${{ inputs.build-command }} ${{ inputs.build-args }} || {
+          echo "::error::Build failed. Please check the logs above for errors."
+          exit 1
+        }
+        echo "::endgroup::"
+
+    - name: List Built Applications
+      if: inputs.run-build == 'true'
+      id: built-apps
+      shell: bash
+      run: |
+        # This is a simple placeholder to list applications
+        # In real usage, you might need to adapt this to your project structure
+        echo "::group::Built Applications"
+        if command -v pnpm &> /dev/null && [ -f "package.json" ]; then
+          echo "pnpm project with package.json found"
+          if grep -q '"workspaces"' package.json; then
+            echo "Workspace project detected"
+            WORKSPACES=$(node -e "console.log(JSON.stringify(require('./package.json').workspaces || []))" | jq -r '.[]')
+            echo "Workspaces: $WORKSPACES"
+          fi
+        fi
+        echo "::endgroup::"
 
 # Define the branding for the action in the GitHub Marketplace
 branding:
-  icon: "box"
+  icon: "package"
   color: "blue"


### PR DESCRIPTION
  1. The action now supports separate configuration for all three stages:
    - Linting with customizable command and arguments
    - Testing with customizable command and arguments
    - Building with customizable command and arguments
  2. Each step can be enabled/disabled independently using run-lint, run-test, and run-build inputs.
  3. The action includes clear error reporting for each stage, showing which phase failed and the exact command that was run.
  4. All commands have sensible defaults that work for standard pnpm projects:
    - pnpm lint for linting
    - pnpm test for testing
    - pnpm build for building
  5. I've updated the README with comprehensive documentation, examples for different frameworks (Vue.js, Next.js, etc.), and troubleshooting tips.
