### PR TITLE
Add project-path parameter for multi-project repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Customized usage with specific commands:
 
 | Name | Description | Default | Required |
 |------|-------------|---------|----------|
-| `project-path` | Path to the project directory containing package.json | `.` | No |
+| `project-path` | Relative path to the project directory (must contain `package.json`) | `.` | No |
 | `node-options` | Node options for all processes | `--max_old_space_size=4096` | No |
 | `archive-coverage` | Whether to archive code coverage results | `false` | No |
 | `coverage-path` | Path to the coverage reports (relative to project-path) | `coverage` | No |
@@ -130,7 +130,7 @@ jobs:
 
 ### Project in a Subdirectory
 
-For repositories where the project is not at the root:
+For repositories where the project is not at the root. The `project-path` must be a relative path within the repository containing `package.json`:
 
 ```yaml
 - name: Setup PNPM
@@ -146,7 +146,9 @@ For repositories where the project is not at the root:
 
 ### Multiple Projects in One Repository
 
-For monorepos with multiple independent projects:
+For repositories with multiple independent PNPM projects (not pnpm workspaces using `pnpm-workspace.yaml`):
+
+> **Note:** This feature is designed for repositories containing multiple separate PNPM projects. For pnpm workspaces, run commands from the workspace root using `pnpm -r` instead (see Workspace Project Example below).
 
 ```yaml
 # Build frontend
@@ -211,47 +213,6 @@ For monorepos with multiple independent projects:
 ### Common Issues
 
 1. **Command not found errors**: Make sure your package.json includes the scripts defined in your lint-command, test-command, and build-command inputs.
-
-2. **Out of memory errors**: If you encounter memory issues during build, increase the memory allocation with the node-options input.
-
-3. **pnpm workspace issues**: For monorepo projects using pnpm workspaces, you may need to use commands like `pnpm -r` to run commands recursively in all packages.
-```yaml
-- name: Build Vue.js Project
-  uses: p6m-actions/js-pnpm-build@v1
-  with:
-    lint-command: 'pnpm lint:vue'
-    test-command: 'pnpm test:unit'
-    build-command: 'pnpm build:prod'
-```
-
-### Next.js Project Example
-
-```yaml
-- name: Build Next.js Project
-  uses: p6m-actions/js-pnpm-build@v1
-  with:
-    lint-command: 'pnpm lint'
-    test-command: 'pnpm test:ci'
-    build-command: 'pnpm build'
-    node-options: '--max_old_space_size=8192' # Next.js may need more memory
-```
-
-### Workspace Project Example
-
-```yaml
-- name: Build Workspace Project
-  uses: p6m-actions/js-pnpm-build@v1
-  with:
-    lint-command: 'pnpm -r lint'
-    test-command: 'pnpm -r test'
-    build-command: 'pnpm -r build'
-```
-
-## Troubleshooting
-
-### Common Issues
-
-1. **Command not found errors**: The action will automatically check if the required scripts exist in package.json and skip steps that don't have corresponding scripts. If you're using custom commands, make sure they're properly defined in your package.json.
 
 2. **Out of memory errors**: If you encounter memory issues during build, increase the memory allocation with the node-options input.
 

--- a/README.md
+++ b/README.md
@@ -85,9 +85,10 @@ Customized usage with specific commands:
 
 | Name | Description | Default | Required |
 |------|-------------|---------|----------|
+| `project-path` | Path to the project directory containing package.json | `.` | No |
 | `node-options` | Node options for all processes | `--max_old_space_size=4096` | No |
 | `archive-coverage` | Whether to archive code coverage results | `false` | No |
-| `coverage-path` | Path to the coverage reports | `coverage` | No |
+| `coverage-path` | Path to the coverage reports (relative to project-path) | `coverage` | No |
 
 ## Examples
 
@@ -123,8 +124,52 @@ jobs:
   uses: p6m-actions/js-pnpm-build@v1
   with:
     run-lint: 'true'
-    run-test: 'false' 
+    run-test: 'false'
     run-build: 'false'
+```
+
+### Project in a Subdirectory
+
+For repositories where the project is not at the root:
+
+```yaml
+- name: Setup PNPM
+  uses: p6m-actions/js-pnpm-setup@v1
+  with:
+    project-path: 'packages/my-app'
+
+- name: Build
+  uses: p6m-actions/js-pnpm-build@v1
+  with:
+    project-path: 'packages/my-app'
+```
+
+### Multiple Projects in One Repository
+
+For monorepos with multiple independent projects:
+
+```yaml
+# Build frontend
+- name: Setup Frontend
+  uses: p6m-actions/js-pnpm-setup@v1
+  with:
+    project-path: 'packages/frontend'
+
+- name: Build Frontend
+  uses: p6m-actions/js-pnpm-build@v1
+  with:
+    project-path: 'packages/frontend'
+
+# Build backend
+- name: Setup Backend
+  uses: p6m-actions/js-pnpm-setup@v1
+  with:
+    project-path: 'packages/backend'
+
+- name: Build Backend
+  uses: p6m-actions/js-pnpm-build@v1
+  with:
+    project-path: 'packages/backend'
 ```
 
 ### Vue.js Project Example

--- a/action.yml
+++ b/action.yml
@@ -47,6 +47,10 @@ inputs:
     default: ""
 
   # General configuration
+  project-path:
+    description: "Path to the project directory containing package.json"
+    required: false
+    default: "."
   node-options:
     description: "Node options for all processes"
     required: false
@@ -73,10 +77,11 @@ runs:
     - name: Lint
       if: inputs.run-lint == 'true'
       shell: bash
+      working-directory: ${{ inputs.project-path }}
       run: |
         echo "::group::Running Lint"
         echo "Running command: ${{ inputs.lint-command }} ${{ inputs.lint-args }}"
-        
+
         # Check if the lint script exists in package.json
         if grep -q "\"lint\":" package.json; then
           ${{ inputs.lint-command }} ${{ inputs.lint-args }} || {
@@ -91,10 +96,11 @@ runs:
     - name: Test
       if: inputs.run-test == 'true'
       shell: bash
+      working-directory: ${{ inputs.project-path }}
       run: |
         echo "::group::Running Tests"
         echo "Running command: ${{ inputs.test-command }} ${{ inputs.test-args }}"
-        
+
         # Check if the test script exists in package.json
         if grep -q "\"test\":" package.json; then
           ${{ inputs.test-command }} ${{ inputs.test-args }} || {
@@ -111,15 +117,16 @@ runs:
       uses: actions/upload-artifact@v4
       with:
         name: test-coverage-report
-        path: ${{ inputs.coverage-path }}
+        path: ${{ inputs.project-path }}/${{ inputs.coverage-path }}
 
     - name: Build
       if: inputs.run-build == 'true'
       shell: bash
+      working-directory: ${{ inputs.project-path }}
       run: |
         echo "::group::Running Build"
         echo "Running command: ${{ inputs.build-command }} ${{ inputs.build-args }}"
-        
+
         # Check if the build script exists in package.json
         if grep -q "\"build\":" package.json; then
           ${{ inputs.build-command }} ${{ inputs.build-args }} || {
@@ -135,6 +142,7 @@ runs:
       if: inputs.run-build == 'true' && success()
       id: built-apps
       shell: bash
+      working-directory: ${{ inputs.project-path }}
       run: |
         # This is a simple placeholder to list applications
         # In real usage, you might need to adapt this to your project structure

--- a/action.yml
+++ b/action.yml
@@ -48,7 +48,7 @@ inputs:
 
   # General configuration
   project-path:
-    description: "Path to the project directory containing package.json"
+    description: "Relative path to the project directory containing package.json (must not contain '..' or be absolute)"
     required: false
     default: "."
   node-options:


### PR DESCRIPTION
## Summary

- Adds optional `project-path` input parameter (default: `.`) to support projects not at repository root
- Adds `working-directory` to all shell steps (Lint, Test, Build, List Built Applications)
- Updates coverage artifact path to be relative to project-path
- Updates README with documentation and examples for subdirectory and multi-project usage

## Why

The action previously assumed projects were at the repository root. This didn't accommodate repos with multiple projects or different layouts (e.g., monorepos, projects in subdirectories).

## Changes

| Step | Change |
|------|--------|
| Lint | Added `working-directory: ${{ inputs.project-path }}` |
| Test | Added `working-directory: ${{ inputs.project-path }}` |
| Archive coverage | Path now `${{ inputs.project-path }}/${{ inputs.coverage-path }}` |
| Build | Added `working-directory: ${{ inputs.project-path }}` |
| List Built Applications | Added `working-directory: ${{ inputs.project-path }}` |

## Usage

```yaml
# Setup and build a project in a subdirectory
- uses: p6m-actions/js-pnpm-setup@v1
  with:
    project-path: "packages/my-app"

- uses: p6m-actions/js-pnpm-build@v1
  with:
    project-path: "packages/my-app"
```

## Test plan

- [ ] Verify action works with default `project-path: "."` (backward compatible)
- [ ] Test with project in subdirectory
- [ ] Test with multiple projects in same workflow

## Related

- Companion PR for js-pnpm-setup: https://github.com/p6m-actions/js-pnpm-setup/pull/1

🤖 Generated with [Claude Code](https://claude.com/claude-code)